### PR TITLE
fix: data path in setyp.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email="steve@watt.am",
     url="https://github.com/StephenWattam/pintless",
     packages=["pintless"],
-    package_data={"pintless": ["pintless/default_units.json"]},
+    package_data={"pintless": ["default_units.json"]},
     include_package_data=True,
     extras_require={"dev": ["flake8"], "test": ["pytest", "pytest-cov"]},
 )


### PR DESCRIPTION
My understanding is the[ package data path ](https://docs.python.org/3/distutils/setupscript.html)should be relative to the `__init__.py` file not the `setup.py` file. 